### PR TITLE
feat: Add interactive crop configuration to web app

### DIFF
--- a/web_app/app.py
+++ b/web_app/app.py
@@ -36,7 +36,7 @@ except ModuleNotFoundError as e:
     def delete_card(card_id): print(f"DUMMY delete_card: {card_id}"); return False
 
 try:
-    from recognition.ocr_mvp import capture_images_from_camera, process_image_to_db, CardNameCorrector
+    from recognition.ocr_mvp import capture_images_from_camera, process_image_to_db, CardNameCorrector, setup_crop_interactively
     # Define DEFAULT_DICT_PATH using project_root_folder, AFTER project_root_folder is defined.
     DEFAULT_DICT_PATH = str(project_root_folder / "recognition" / "cards" / "card_names_symspell_clean.txt")
 except ModuleNotFoundError as e:
@@ -87,6 +87,14 @@ except Exception as e:
 @app.route('/')
 def index():
     return render_template('index.html') # Serve the main HTML page
+
+@app.route('/configure_crop', methods=['POST'])
+def configure_crop_route():
+    try:
+        setup_crop_interactively()
+        return jsonify({"message": "Crop configuration process started. Check server display."}), 200
+    except Exception as e:
+        return jsonify({"error": "Failed to start crop configuration", "details": str(e)}), 500
 
 @app.route('/scan', methods=['POST'])
 def scan_card():

--- a/web_app/static/js/script.js
+++ b/web_app/static/js/script.js
@@ -7,6 +7,28 @@ document.addEventListener('DOMContentLoaded', () => {
     const manaCostFilterInput = document.getElementById('manaCostFilter');
     const applyFilterButton = document.getElementById('applyFilterButton');
     const clearFilterButton = document.getElementById('clearFilterButton');
+    const configureCropButton = document.getElementById('configureCropButton');
+
+    if (configureCropButton) {
+        configureCropButton.addEventListener('click', async () => {
+            scanStatusDiv.textContent = 'Attempting to open crop configuration tool on the server... Please check the server display.';
+            configureCropButton.disabled = true;
+            try {
+                const response = await fetch('/configure_crop', { method: 'POST' });
+                const result = await response.json();
+                if (response.ok) {
+                    scanStatusDiv.textContent = result.message || 'Crop configuration initiated. Check server display.';
+                } else {
+                    throw new Error(result.error || 'Failed to start crop configuration.');
+                }
+            } catch (error) {
+                console.error('Error during crop configuration:', error);
+                scanStatusDiv.textContent = 'Error during crop configuration: ' + error.message;
+            } finally {
+                configureCropButton.disabled = false;
+            }
+        });
+    }
 
     const fetchAndDisplayCards = async () => {
         scanStatusDiv.textContent = 'Loading cards...';

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -12,6 +12,7 @@
 
         <div class="controls">
             <button id="scanButton">Scan Card</button>
+            <button id="configureCropButton">Configure Crop Coordinates</button> <!-- New button -->
             <a href="/export/csv" class="button" id="downloadCsvButton">Download CSV</a>
         </div>
 


### PR DESCRIPTION
This commit introduces a feature allowing you to configure crop coordinates interactively through the web application.

Key changes:
- Added a "Configure Crop Coordinates" button to the web interface (`index.html`).
- Implemented a new backend Flask endpoint (`/configure_crop` in `app.py`) that calls the existing `setup_crop_interactively` function from `recognition.ocr_mvp.py`. This function uses `libcamera-still` to capture an image and `matplotlib` to display an interactive crop selection window on the server.
- Added JavaScript (`script.js`) to handle the button click, call the new endpoint, and display status messages to you.
- The crop coordinates are stored as global variables within the `recognition.ocr_mvp` module and persist for the lifetime of the server process, affecting all subsequent card scans.

The flow for configuring crop coordinates is now identical to running `main.py --configure_crop`, as you requested. I confirmed the functionality works as expected.