### PR TITLE
feat: Enhance card display, add filters, and card summaries

### DIFF
--- a/web_app/app.py
+++ b/web_app/app.py
@@ -121,9 +121,18 @@ def get_all_cards():
     mana_cost_str = request.args.get('mana_cost')
     mana_cost = None
     if mana_cost_str:
-        try: mana_cost = int(mana_cost_str)
+        try: mana_cost = int(mana_cost_str) # The database expects float for cmc, but API uses int for mana_cost. This might need alignment. For now, respecting existing int conversion.
         except ValueError: return jsonify({"error": "Invalid mana_cost parameter"}), 400
-    cards_data = get_cards(color=color, mana_cost=mana_cost)
+
+    max_price_str = request.args.get('max_price')
+    max_price = None
+    if max_price_str:
+        try:
+            max_price = float(max_price_str)
+        except ValueError:
+            return jsonify({"error": "Invalid max_price parameter"}), 400
+
+    cards_data = get_cards(color=color, mana_cost=mana_cost, max_price=max_price)
     return jsonify(cards_data), 200
 
 @app.route('/export/csv', methods=['GET'])

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -24,8 +24,16 @@
             <label for="manaCostFilter">Filter by Mana Cost (CMC):</label>
             <input type="number" id="manaCostFilter" placeholder="e.g., 2">
 
+            <label for="maxPriceFilter">Filter by Max Price:</label>
+            <input type="number" id="maxPriceFilter" placeholder="e.g., 10.50" step="0.01">
+
             <button id="applyFilterButton">Apply Filters</button>
             <button id="clearFilterButton">Clear Filters</button>
+        </div>
+
+        <div class="summary-stats">
+            <p id="cardCountDisplay">Loading card count...</p>
+            <p id="totalPriceDisplay">Loading total price...</p>
         </div>
 
         <h2>Scanned Cards</h2>


### PR DESCRIPTION
This commit implements several enhancements to your Magic card web application:

1.  **Card Tile Adjustments:**
    *   Removes the local image path display from card details.
    *   Adds a link to the card's image on Scryfall (using `image_uri`).
    *   Displays Converted Mana Cost (CMC) and Card Type (`type_line`) for each card.
    *   `recognition/ocr_mvp.py` updated to fetch CMC, type, and image URI from Scryfall.

2.  **Price Filter:**
    *   Adds a "Max Price" filter to the UI and backend.
    *   You can now filter cards based on a maximum price.

3.  **Card Statistics:**
    *   Displays a dynamic count of all scanned/filtered cards.
    *   Displays the total sum of the "Price" for all scanned/filtered cards.

4.  **Backend Updates:**
    *   `web_app/database.py`: Schema updated to store `cmc`, `type_line`, and `image_uri`. `add_card` and `get_cards` modified accordingly. `get_cards` now supports filtering by `cmc` and `max_price`.
    *   `web_app/app.py`: `/cards` endpoint updated to handle `max_price` filter.

5.  **Frontend Updates:**
    *   `web_app/static/js/script.js`: Updated to display new card fields, handle new filters, and calculate/display card statistics.
    *   `web_app/templates/index.html`: Updated with new filter input and display areas for statistics.

6.  **Testing:**
    *   Added and updated tests in `tests/test_ocr_mvp.py` and `tests/test_web_app.py` to cover the new functionality, including API interactions, database changes, and new filter logic.