### PR TITLE
feat: Add EDHREC-based deck suggestions

### DIFF
--- a/web_app/database.py
+++ b/web_app/database.py
@@ -81,6 +81,19 @@ def get_cards(color: str = None, mana_cost: float = None, max_price: float = Non
     # Convert sqlite3.Row objects to dictionaries for easier JSON serialization
     return [dict(card) for card in cards]
 
+def get_legendary_creatures():
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    query = "SELECT id, name, ocr_name_raw, price, color_identity, image_path, strftime('%Y-%m-%d %H:%M:%S', timestamp) as timestamp, cmc, type_line, image_uri FROM cards WHERE type_line LIKE 'Legendary Creature%'"
+
+    cursor.execute(query)
+    cards = cursor.fetchall()
+    conn.close()
+
+    # Convert sqlite3.Row objects to dictionaries for easier JSON serialization
+    return [dict(card) for card in cards]
+
 def delete_card(card_id: int):
     conn = get_db_connection()
     cursor = conn.cursor()
@@ -157,3 +170,11 @@ if __name__ == '__main__':
     print(f"\nAttempting to delete non-existent card ID: {non_existent_id}")
     delete_non_existent_success = delete_card(non_existent_id)
     print(f"Deletion of non-existent card ID {non_existent_id} was {'successful' if delete_non_existent_success else 'unsuccessful (expected)'}.")
+
+    print("\nLegendary Creatures:")
+    legendary_cards = get_legendary_creatures()
+    if legendary_cards:
+        for lc in legendary_cards:
+            print(f"ID: {lc['id']}, Name: {lc['name']}, Type: {lc['type_line']}")
+    else:
+        print("No legendary creatures found.")

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -14,6 +14,7 @@
             <button id="scanButton">Scan Card</button>
             <button id="configureCropButton">Configure Crop Coordinates</button> <!-- New button -->
             <a href="/export/csv" class="button" id="downloadCsvButton">Download CSV</a>
+            <a href="{{ url_for('deck_suggestions_route') }}" class="button" id="deckSuggestionsButton">Deck Suggestions</a>
         </div>
 
         <div class="filters">

--- a/web_app/templates/suggestions.html
+++ b/web_app/templates/suggestions.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deck Suggestions</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <style>
+        .container {
+            max-width: 800px;
+            margin: 20px auto;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+        }
+        .commander-card img {
+            max-width: 200px; /* Or a suitable size */
+            border-radius: 10px;
+            margin-bottom: 15px;
+        }
+        ul {
+            list-style-type: none;
+            padding: 0;
+        }
+        li {
+            padding: 5px 0;
+            border-bottom: 1px solid #eee;
+        }
+        li:last-child {
+            border-bottom: none;
+        }
+        a.button-back {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 10px 15px;
+            background-color: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        a.button-back:hover {
+            background-color: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Deck Suggestions</h1>
+
+        {% if error_message %}
+            <p style="color: red;">{{ error_message }}</p>
+        {% elif message %}
+            <p>{{ message }}</p>
+        {% elif commander_name and suggested_cards %}
+            <h2>Best Commander for You: {{ commander_name }}</h2>
+            <p>Found {{ match_count }} matching cards in your collection!</p>
+
+            {% if commander_image_uri %}
+                <div class="commander-card">
+                    <img src="{{ commander_image_uri }}" alt="{{ commander_name }}">
+                </div>
+            {% endif %}
+
+            <h3>Suggested Cards You Own:</h3>
+            {% if suggested_cards %}
+                <ul>
+                    {% for card in suggested_cards %}
+                        <li>{{ card }}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p>No specific EDHREC suggested cards found in your collection for this commander, though it was the best match overall.</p>
+            {% endif %}
+        {% else %}
+            <!-- Fallback message, though covered by message/error_message -->
+            <p>No suggestions available at the moment. Try adding more cards to your collection!</p>
+        {% endif %}
+
+        <a href="{{ url_for('index') }}" class="button-back">Back to Main Page</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This feature introduces a "Deck Suggestions" button to the web interface.

When clicked, I will:
1. Identify all legendary creatures in your scanned card database.
2. For each legendary creature, fetch card recommendations from the EDHREC API, collecting cards from all available categories.
3. Compare these EDHREC suggestions against your card collection.
4. Select the commander that has the highest number of matching cards.
5. Display the chosen commander's name, their image (via Scryfall URI), and a list of the EDHREC-recommended cards that are present in your database.

Key changes include:
- Added `get_legendary_creatures()` to `web_app/database.py`.
- Created `fetch_all_edhrec_cards()` in `web_app/app.py` to interact with the EDHREC JSON API, including commander name formatting.
- Implemented a new route `/deck_suggestions` in `web_app/app.py` containing the core suggestion logic and case-insensitive card name matching.
- Added a "Deck Suggestions" button to `web_app/templates/index.html`.
- Created `web_app/templates/suggestions.html` to display the results.
- Ensured error handling for API calls and various scenarios (e.g., no legendaries found).